### PR TITLE
WIP: Change Multus to use CRDs for additional networks

### DIFF
--- a/components/network/macvlan-net-attach-def.yaml
+++ b/components/network/macvlan-net-attach-def.yaml
@@ -1,0 +1,13 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvlan-network
+spec:
+  config: '{
+       "type": "macvlan",
+       "master": "eth0",
+       "ipam": {
+         "type": "host-local",
+         "subnet": "172.72.0.0/24"
+       }
+    }'

--- a/components/network/multus-clusterrole.yaml
+++ b/components/network/multus-clusterrole.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: multus-crd-overpowered
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'

--- a/components/network/multus-cni-configmap.yaml
+++ b/components/network/multus-cni-configmap.yaml
@@ -29,19 +29,5 @@ data:
          "kubernetes": {
            "kubeconfig": "/etc/kubernetes/node-kubeconfig.yaml"
          }
-       },{
-         "name": "net0",
-         "type": "macvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "host-local",
-           "subnet": "172.72.0.0/24"
-           ### Example of IP addresses range, change according to your needs.
-           ### Note that this example range limits the whole cluster for 50 pods
-           ### As 50 (250 minus 200) IP addresses can be assigned only.
-           ### Remove these lines (all comments including range) if do not use.
-           #,"rangeStart": "172.72.0.200",
-           #"rangeEnd": "172.72.0.250"
-         }
        }]
       }

--- a/components/network/multus-cni-daemonset.yaml
+++ b/components/network/multus-cni-daemonset.yaml
@@ -15,6 +15,9 @@ spec:
         app: multus-cni
     spec:
       terminationGracePeriodSeconds: 0
+      tolerations:
+      - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
       containers:
       - name: cni-installer
         image: travelping/cni-installer

--- a/components/network/multus-crd.yml
+++ b/components/network/multus-crd.yml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: network-attachment-definitions
+    singular: network-attachment-definition
+    kind: NetworkAttachmentDefinition
+    shortNames:
+    - net-attach-def
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            config:
+                 type: string


### PR DESCRIPTION
Instead of using a global configuration which injects additional network
interfaces to *every* pod, use a CRD `NetworkAttachDefinition` to have
configurations for additional CNIs in CRDs and refer to those by an
annotation on the pod. Hence, only the pods that *require* additional
interfaces will have those.

This is the "defacto standard" and recommended configuration by Multus:
https://github.com/intel/multus-cni#kubernetes-network-custom-resource-definition-de-facto-standard---reference-implementation