### PR TITLE
fix error Invalid output name in packet terraform

### DIFF
--- a/infra/packet/nodes-output.tf
+++ b/infra/packet/nodes-output.tf
@@ -1,15 +1,15 @@
-output "Master IPs public" {
+output "Master_IPs_public" {
     value = "${join(", ", (packet_device.master.*.access_public_ipv4))}"
 }
 
-output "Master IPs private" {
+output "Master_IPs_private" {
     value = "${join(", ", (packet_device.master.*.access_private_ipv4))}"
 }
 
-output "Worker IPs public" {
+output "Worker_IPs_public" {
     value = "${join(", ", (packet_device.worker.*.access_public_ipv4))}"
 }
 
-output "Worker IPs private" {
+output "Worker_IPs_private" {
     value = "${join(", ", (packet_device.worker.*.access_private_ipv4))}"
 }


### PR DESCRIPTION
I had an error (see below) when running terraform.

Terraform v0.12.9 wsl2 on win10

`Error: Invalid output name                                                                                                                                                                                                   
  on nodes-output.tf line 5, in output "Master IPs private":
   5: output "Master IPs private" {                                                                                                                                                                                            
A name must start with a letter and may contain only letters, digits,
underscores, and dashes.`

